### PR TITLE
changed enroll now in MENU from landingpage

### DIFF
--- a/landingpage/Announcements.html
+++ b/landingpage/Announcements.html
@@ -111,6 +111,9 @@
                 <li>
                   <a href="tor.html">Transcript of Record</a>
                 </li>
+                <li>
+                  <a href="enrollment.php">Enroll Now !</a>
+                </li>
               </ul>
             </li>
             <li><a href="elements.html">Contact Us</a></li>

--- a/landingpage/courses.html
+++ b/landingpage/courses.html
@@ -121,6 +121,10 @@
                 <li>
                   <a href="tor.html">Transcript of Record</a>
                 </li>
+                
+                <li>
+                  <a href="enrollment.php">Enroll Now !</a>
+                </li>
               </ul>
             </li>
             <li><a href="elements.html">Contact Us</a></li>

--- a/landingpage/enrollment.php
+++ b/landingpage/enrollment.php
@@ -183,6 +183,7 @@ mysqli_close($conn);
                             <li><a href="Announcements.html">Announcements</a></li>
                             <li><a href="school calendar.html">School Calendar</a></li>
                             <li><a href="courses.html">SHS Strands</a></li>
+                            <!--
                             <li>
                                 <a href="#">Resources</a>
                                 <ul>
@@ -195,6 +196,14 @@ mysqli_close($conn);
                                     <li><a href="#">Support</a></li>
                                     <li><a href="#">Feedbacks</a></li>
                                 </ul>
+                            </li>
+                            -->
+                            <li>
+                                <a href="tor.html">Transcript of Record</a>
+                            </li>
+                            
+                            <li>
+                            <a href="enrollment.php">Enroll Now !</a>
                             </li>
                         </ul>
                     </li>

--- a/landingpage/school calendar.html
+++ b/landingpage/school calendar.html
@@ -111,6 +111,10 @@
                 <li>
                   <a href="tor.html">Transcript of Record</a>
                 </li>
+                
+                <li>
+                  <a href="enrollment.php">Enroll Now !</a>
+                </li>
               </ul>
             </li>
             <li><a href="elements.html">Contact Us</a></li>

--- a/landingpage/tor.html
+++ b/landingpage/tor.html
@@ -163,6 +163,10 @@
                 <li><a href="school calendar.html">School Calendar</a></li>
                 <li><a href="courses.html">SHS Strands</a></li>
                 <li>
+                  <a href="tor.html">Transcript of Record</a>
+                </li>
+                <!--
+                  <li>
                   <a href="#">Resources</a>
                   <ul>
                     <li><a href="#">Admission</a></li>
@@ -171,6 +175,10 @@
                     <li><a href="#">Support</a></li>
                     <li><a href="#">Feedbacks</a></li>
                   </ul>
+                </li>
+                -->
+                <li>
+                  <a href="enrollment.php">Enroll Now !</a>
                 </li>
               </ul>
             </li>


### PR DESCRIPTION
navigation bar between landing pages has missing links such as "transcript of record" and "enroll now"